### PR TITLE
Fix links to PHP-FIG standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ None yet.
 | [PSR-2 Coding Style Guide](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)
 | [PSR-3 Logge Interface](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md)
 | [PSR-4 Autoloader](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-4-autoloader.md)
-| [PSR-6 Caching Interface](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-4-autoloader.md)
-| [PSR-7 HTTP Message Interface](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-4-autoloader.md)
+| [PSR-6 Caching Interface](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-6-cache.md)
+| [PSR-7 HTTP Message Interface](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-7-http-message.md)
 
 
 ## How this works


### PR DESCRIPTION
Couple of the links for the FIG standards incorrectly point to PSR-4.
