### PR TITLE
Add description for PSR-0

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ None yet.
 
 |  Name|
 |------|
-| [PSR-0](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md)
+| [PSR-0 Autoloading Standard (deprecated)](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md)
 | [PSR-1 Basic Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-1-basic-coding-standard.md)
 | [PSR-2 Coding Style Guide](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)
 | [PSR-3 Logger Interface](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md)


### PR DESCRIPTION
PSR-0 is autoloading standart, but it's deprecated since PSR-4.
